### PR TITLE
[KANBAN-6] Fix item removal by consistently using addRemoveButton

### DIFF
--- a/src/main/resources/Macros/AWMKanbanMacro.xml
+++ b/src/main/resources/Macros/AWMKanbanMacro.xml
@@ -381,7 +381,7 @@ ul.card-field-list {
 #set($width = "$xcontext.macro.params.width")
 #set($source = $xwiki.getDocument("Macros.KanbanAWMSource").getURL("get", "xpage=plain&amp;outputSyntax=plain&amp;className=${escapetool.url($className)}&amp;category=${escapetool.url($category)}&amp;displayedCategoryColumns=${escapetool.url($displayedCategoryColumns)}&amp;title=${escapetool.url($title)}&amp;columns=${escapetool.url($columns)}&amp;xwql=${escapetool.url($xwql)}&amp;colors=${escapetool.url($colors)}"))
 #set($awmupdatepath = "/objects/${className}/0/properties/${category}/")
-{{kanban source="${source}" updateService="" addBoardButton="false" addItemButton="false" removeBoardButton="false" removeItemButton="false" awmupdatepath="${awmupdatepath}" width="${width}" /}}
+{{kanban source="${source}" updateService="" addBoardButton="false" addItemButton="false" removeBoardButton="false" addRemoveItem="false" awmupdatepath="${awmupdatepath}" width="${width}" /}}
 {{/velocity}}
 </code>
     </property>

--- a/src/main/resources/Macros/AWMKanbanMacro.xml
+++ b/src/main/resources/Macros/AWMKanbanMacro.xml
@@ -381,7 +381,7 @@ ul.card-field-list {
 #set($width = "$xcontext.macro.params.width")
 #set($source = $xwiki.getDocument("Macros.KanbanAWMSource").getURL("get", "xpage=plain&amp;outputSyntax=plain&amp;className=${escapetool.url($className)}&amp;category=${escapetool.url($category)}&amp;displayedCategoryColumns=${escapetool.url($displayedCategoryColumns)}&amp;title=${escapetool.url($title)}&amp;columns=${escapetool.url($columns)}&amp;xwql=${escapetool.url($xwql)}&amp;colors=${escapetool.url($colors)}"))
 #set($awmupdatepath = "/objects/${className}/0/properties/${category}/")
-{{kanban source="${source}" updateService="" addBoardButton="false" addItemButton="false" removeBoardButton="false" addRemoveItem="false" awmupdatepath="${awmupdatepath}" width="${width}" /}}
+{{kanban source="${source}" updateService="" addBoardButton="false" addItemButton="false" removeBoardButton="false" addRemoveButton="false" awmupdatepath="${awmupdatepath}" width="${width}" /}}
 {{/velocity}}
 </code>
     </property>

--- a/src/main/resources/Macros/KanbanMacro.xml
+++ b/src/main/resources/Macros/KanbanMacro.xml
@@ -60,7 +60,7 @@ Additional parameters:
 * ##addBoardButton## display the add Board button (default true)
 * ##addItemButton## display the add Item button (default true)
 * ##removeBoardButton## display the remove Board button (default true)
-* ##removeBoardItem## allow removing Item by drag and dropping them out of a board (default true)
+* ##addRemoveButton## allow removing Item by drag and dropping them out of a board (default true)
 
 == Example ==
 

--- a/src/main/resources/Macros/KanbanMacro.xml
+++ b/src/main/resources/Macros/KanbanMacro.xml
@@ -43,7 +43,7 @@
 The macro can take the JSON of the kanban either from the content of the macro or from an URL. There is also the [[xwiki:Macros.AWMKanbanMacro]] allowing to display a kanban board from AppWithinMinutes data.
 
 ##{{{
-{{kanban width="30%" source="" updateService="" addBoardButton="true" addItemButton="true" removeBoardButton="true" removeBoardItem="true"}}
+{{kanban width="30%" source="" updateService="" addBoardButton="true" addItemButton="true" removeBoardButton="true" addRemoveButton="true"}}
 [
  {"id":"board1","title":"To Do","color":"red","item":[{"title":"Item 1"},{"title":"Item 2"}]},
  {"id":"board2","title":"Working","color":"blue","item":[{"title":"Item 3"},{"title":"Item 4"}]},
@@ -2381,8 +2381,8 @@ require(['jquery','jkanban'], function(jQuery) {
 #if($xcontext.macro.params.removeBoardButton)            
             removeBoardButton: ${xcontext.macro.params.removeBoardButton},
 #end
-#if($xcontext.macro.params.removeItemButton)            
-            removeItemButton: ${xcontext.macro.params.removeItemButton},
+#if($xcontext.macro.params.addRemoveButton)            
+            addRemoveButton: ${xcontext.macro.params.addRemoveButton},
 #end
             boards: boards
         });


### PR DESCRIPTION
Fixes the issue described in [KANBAN-6] by consistenly using the name `addRemoveButton` in KanbanMacro.