### PR TITLE
Kanban 8: Add the ability to select colors for the Kanban boards

### DIFF
--- a/src/main/resources/Macros/AWMKanbanMacro.xml
+++ b/src/main/resources/Macros/AWMKanbanMacro.xml
@@ -365,9 +365,17 @@ ul.card-field-list {
   ## We don't override the xwql variable in case it was defined externally by another macro calling this one (e.g. TaskManager.KanbanBoardMacro).
   #set($xwql = "")
 #end
+#if ($$xcontext.macro.params.colors)
+  #set($colors = $xcontext.macro.params.colors)
+#elseif (!$colors)
+  ## We don't override the colors variable in case it was defined externally by another macro calling this one (e.g. TaskManager.KanbanBoardMacro).
+  ## We set as default the original colors: green,blue,orange,yellow,red
+  #set($colors = "#8C4,#0AC,#F91,#FC3,#E43")
+#end
+
 #set($width = "$xcontext.macro.params.width")
-#set($source = $xwiki.getDocument("Macros.KanbanAWMSource").getURL("get", "xpage=plain&amp;outputSyntax=plain&amp;className=${escapetool.url($className)}&amp;category=${escapetool.url($category)}&amp;title=${escapetool.url($title)}&amp;columns=${escapetool.url($columns)}&amp;xwql=${escapetool.url($xwql)}"))
-#set($awmupdatepath = "/objects/${className}/0/properties/${category}/")   
+#set($source = $xwiki.getDocument("Macros.KanbanAWMSource").getURL("get", "xpage=plain&amp;outputSyntax=plain&amp;className=${escapetool.url($className)}&amp;category=${escapetool.url($category)}&amp;title=${escapetool.url($title)}&amp;columns=${escapetool.url($columns)}&amp;xwql=${escapetool.url($xwql)}&amp;colors=${escapetool.url($colors)}"))
+#set($awmupdatepath = "/objects/${className}/0/properties/${category}/")
 {{kanban source="${source}" updateService="" addBoardButton="false" addItemButton="false" removeBoardButton="false" removeItemButton="false" awmupdatepath="${awmupdatepath}" width="${width}" /}}
 {{/velocity}}
 </code>
@@ -923,6 +931,87 @@ ul.card-field-list {
     </property>
     <property>
       <name>width</name>
+    </property>
+    <property>
+      <type/>
+    </property>
+  </object>
+  <object>
+    <name>Macros.AWMKanbanMacro</name>
+    <number>11</number>
+    <className>XWiki.WikiMacroParameterClass</className>
+    <guid>3ff1e776-4419-491b-8c63-8e01c5dc6b37</guid>
+    <class>
+      <name>XWiki.WikiMacroParameterClass</name>
+      <customClass/>
+      <customMapping/>
+      <defaultViewSheet/>
+      <defaultEditSheet/>
+      <defaultWeb/>
+      <nameField/>
+      <validationScript/>
+      <defaultValue>
+        <disabled>0</disabled>
+        <name>defaultValue</name>
+        <number>4</number>
+        <prettyName>Parameter default value</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </defaultValue>
+      <description>
+        <disabled>0</disabled>
+        <name>description</name>
+        <number>2</number>
+        <prettyName>Parameter description</prettyName>
+        <rows>5</rows>
+        <size>40</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
+      </description>
+      <mandatory>
+        <disabled>0</disabled>
+        <displayFormType>select</displayFormType>
+        <displayType>yesno</displayType>
+        <name>mandatory</name>
+        <number>3</number>
+        <prettyName>Parameter mandatory</prettyName>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
+      </mandatory>
+      <name>
+        <disabled>0</disabled>
+        <name>name</name>
+        <number>1</number>
+        <prettyName>Parameter name</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </name>
+      <type>
+        <disabled>0</disabled>
+        <name>type</name>
+        <number>5</number>
+        <prettyName>Parameter type</prettyName>
+        <size>60</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </type>
+    </class>
+    <property>
+      <defaultValue/>
+    </property>
+    <property>
+      <description>List of colors separated by commas, each color corresponds to a column.</description>
+    </property>
+    <property>
+      <mandatory/>
+    </property>
+    <property>
+      <name>colors</name>
+    </property>
+    <property>
+      <type/>
     </property>
   </object>
 </xwikidoc>

--- a/src/main/resources/Macros/AWMKanbanMacro.xml
+++ b/src/main/resources/Macros/AWMKanbanMacro.xml
@@ -365,10 +365,9 @@ ul.card-field-list {
   ## We don't override the xwql variable in case it was defined externally by another macro calling this one (e.g. TaskManager.KanbanBoardMacro).
   #set($xwql = "")
 #end
-#if ($$xcontext.macro.params.colors)
+#if ($xcontext.macro.params.colors)
   #set($colors = $xcontext.macro.params.colors)
-#elseif (!$colors)
-  ## We don't override the colors variable in case it was defined externally by another macro calling this one (e.g. TaskManager.KanbanBoardMacro).
+#else
   ## We set as default the original colors: green,blue,orange,yellow,red
   #set($colors = "#8C4,#0AC,#F91,#FC3,#E43")
 #end

--- a/src/main/resources/Macros/KanbanAWMSource.xml
+++ b/src/main/resources/Macros/KanbanAWMSource.xml
@@ -40,97 +40,99 @@
   <syntaxId>xwiki/2.1</syntaxId>
   <hidden>true</hidden>
   <content>{{velocity wiki='false'}}
-#set($ok = $response.setContentType("application/json"))
-#set($colors = ["yellow", "green", "blue", "orange", "red"])
-#macro(displayCategories $categories $docLists)
-#set($map = [])
-#foreach($categoryValue in $categories)
-     #set($fakedoc = $xwiki.getDocument("XWiki.FakeDocument"))
-     #set($fakeobj = $fakedoc.getObject($className, true))
-     #set($discard = $fakedoc.use($fakeobj))
-     #set($discard = $fakedoc.set($category, $categoryValue))
-     #set($scategoryValue = $fakedoc.display($category, "view", $fakeobj).replaceFirst($regextool.quote('{{html clean="false" wiki="false"}}'), '').replaceAll("$regextool.quote('{{/html}}')$", ''))
-     #set($items = [])
-     #foreach($docname in $docLists.get($categoryValue))
-              #set($currentDoc = $xwiki.getDocument($docname))
-              #set($surl = $currentDoc.getURL("view"))
-              #if($request.title &amp;&amp; $request.title != "")
-               #if($request.title=="title")
-                #set($title = $currentDoc.title)
-               #else
-                #set($stitle = $currentDoc.display($request.title))
-               #end
-              #else
-               #set($stitle = $currentDoc.getDisplayTitle())
-              #end
-              #set($scontent = "")
-              #if($request.columns &amp;&amp; $request.columns!="")
-               #set($scontent = "&lt;ul class='card-field-list'&gt;")
-               #foreach($col in $request.columns.split(","))
-                #set($value = $currentDoc.display($col).replaceFirst($regextool.quote('{{html clean="false" wiki="false"}}'), '').replaceAll("$regextool.quote('{{/html}}')$", ''))
-                #set($pname = $currentDoc.displayPrettyName($col))
-                #set($scontent = "${scontent}&lt;li class='card-field'&gt;&lt;span class='card-field-title''&gt;${escapetool.xml($pname)}&lt;/span&gt;&lt;span class='card-field-value'&gt;$value&lt;/span&gt;&lt;/li&gt;")
-               #end
-               #set($scontent = "${scontent}&lt;/ul&gt;")
-              #end
-              #set($itemmap = { "id" : $docname, "title" : $stitle, "url": $surl, "content" : $scontent })
-              #set($ok = $items.add($itemmap))
-      #end
-     #set($color = $listtool.get($colors, $velocityCount))
-     #if(!$color)
-      #set($color = "blue")
+#if ($xcontext.action == 'get')
+  #set($ok = $response.setContentType("application/json"))
+  #set($colors = $request.colors.split(','))
+  #macro(displayCategories $categories $docLists)
+  #set($map = [])
+  #foreach($categoryValue in $categories)
+       #set($fakedoc = $xwiki.getDocument("XWiki.FakeDocument"))
+       #set($fakeobj = $fakedoc.getObject($className, true))
+       #set($discard = $fakedoc.use($fakeobj))
+       #set($discard = $fakedoc.set($category, $categoryValue))
+       #set($scategoryValue = $fakedoc.display($category, "view", $fakeobj).replaceFirst($regextool.quote('{{html clean="false" wiki="false"}}'), '').replaceAll("$regextool.quote('{{/html}}')$", ''))
+       #set($items = [])
+       #foreach($docname in $docLists.get($categoryValue))
+                #set($currentDoc = $xwiki.getDocument($docname))
+                #set($surl = $currentDoc.getURL("view"))
+                #if($request.title &amp;&amp; $request.title != "")
+                 #if($request.title=="title")
+                  #set($title = $currentDoc.title)
+                 #else
+                  #set($stitle = $currentDoc.display($request.title))
+                 #end
+                #else
+                 #set($stitle = $currentDoc.getDisplayTitle())
+                #end
+                #set($scontent = "")
+                #if($request.columns &amp;&amp; $request.columns!="")
+                 #set($scontent = "&lt;ul class='card-field-list'&gt;")
+                 #foreach($col in $request.columns.split(","))
+                  #set($value = $currentDoc.display($col).replaceFirst($regextool.quote('{{html clean="false" wiki="false"}}'), '').replaceAll("$regextool.quote('{{/html}}')$", ''))
+                  #set($pname = $currentDoc.displayPrettyName($col))
+                  #set($scontent = "${scontent}&lt;li class='card-field'&gt;&lt;span class='card-field-title''&gt;${escapetool.xml($pname)}&lt;/span&gt;&lt;span class='card-field-value'&gt;$value&lt;/span&gt;&lt;/li&gt;")
+                 #end
+                 #set($scontent = "${scontent}&lt;/ul&gt;")
+                #end
+                #set($itemmap = { "id" : $docname, "title" : $stitle, "url": $surl, "content" : $scontent })
+                #set($ok = $items.add($itemmap))
+        #end
+       #set($color = $listtool.get($colors, $foreach.index).strip())
+       #if(!$color)
+        #set($color = "blue")
+       #end
+       #set($ok = $map.add({ "id" : $categoryValue, "title" : $scategoryValue, "color" : "${color}", "item" : $items }))
      #end
-     #set($ok = $map.add({ "id" : $categoryValue, "title" : $scategoryValue, "color" : "${color}", "item" : $items }))
+  $jsontool.serialize(${map})
+  #end
+  #if($request.className||$request.app)
+  #set($app = $request.app)
+  #set($className = $request.className)
+  #if(!$className || $className=="")
+   #set($appDoc = $xwiki.getDocument("${app}.WebHome"))
+   #set($className = $appDoc.getValue("class"))
+  #end
+  #set($category = $request.category)
+  #set($results = $services.query)
+  #set($query = "from doc.object(${className}) as obj where doc.fullName not like '%Template'")
+  #set($xwql = $request.xwql)
+  #if($xwql &amp;&amp; $xwql!="")
+   #set($query = "${query} and ${xwql}")
+  #end
+  #set($order = $request.order)
+  #if($order &amp;&amp; $order!="")
+   #if($order.startsWith("doc"))
+    #set($query = "${query} order by ${order}")
+   #else
+    #set($query = "${query} order by obj.${order}")
    #end
-$jsontool.serialize(${map})
-#end
-#if($request.className||$request.app)
-#set($app = $request.app)
-#set($className = $request.className)
-#if(!$className || $className=="")
- #set($appDoc = $xwiki.getDocument("${app}.WebHome"))
- #set($className = $appDoc.getValue("class"))
-#end
-#set($category = $request.category)
-#set($results = $services.query)
-#set($query = "from doc.object(${className}) as obj where doc.fullName not like '%Template'")
-#set($xwql = $request.xwql)
-#if($xwql &amp;&amp; $xwql!="")
- #set($query = "${query} and ${xwql}")
-#end
-#set($order = $request.order)
-#if($order &amp;&amp; $order!="")
- #if($order.startsWith("doc"))
-  #set($query = "${query} order by ${order}")
- #else
-  #set($query = "${query} order by obj.${order}")
- #end
-#end
-#if($request.debug)
-/* {{{ $query }}} */
-#end
-#set($results = $results.xwql($query).setLimit(50))
-#set($results = $results.execute())
-#if($request.debug)
-/* {{{ $results }}} */
-#end
-#set($categoryField = $xwiki.getDocument($className).getxWikiClass().get($category))
-#set($categories = $categoryField.getListValues())
-#set($categoriesDocs = $util.hashMap)
-#foreach($currentpage in $results)
-  #set($currentdoc = $xwiki.getDocument($currentpage))
-  #set($value = $currentdoc.getValue($category))
-  #if(!$categories.contains($value))
-   #set($discard = $categories.add($value))
   #end
-  #set($docList = $categoriesDocs.get($value))
-  #if(!$docList)
-   #set($docList = $util.arrayList)
-   #set($discard = $categoriesDocs.put($value, $docList))
+  #if($request.debug)
+  /* {{{ $query }}} */
   #end
-  #set($discard = $docList.add($currentdoc.prefixedFullName))
-#end
-#displayCategories($categories $categoriesDocs)
+  #set($results = $results.xwql($query).setLimit(50))
+  #set($results = $results.execute())
+  #if($request.debug)
+  /* {{{ $results }}} */
+  #end
+  #set($categoryField = $xwiki.getDocument($className).getxWikiClass().get($category))
+  #set($categories = $categoryField.getListValues())
+  #set($categoriesDocs = $util.hashMap)
+  #foreach($currentpage in $results)
+    #set($currentdoc = $xwiki.getDocument($currentpage))
+    #set($value = $currentdoc.getValue($category))
+    #if(!$categories.contains($value))
+     #set($discard = $categories.add($value))
+    #end
+    #set($docList = $categoriesDocs.get($value))
+    #if(!$docList)
+     #set($docList = $util.arrayList)
+     #set($discard = $categoriesDocs.put($value, $docList))
+    #end
+    #set($discard = $docList.add($currentdoc.prefixedFullName))
+  #end
+  #displayCategories($categories $categoriesDocs)
+  #end
 #end
 {{/velocity}}</content>
 </xwikidoc>

--- a/src/main/resources/Macros/KanbanMacro.xml
+++ b/src/main/resources/Macros/KanbanMacro.xml
@@ -207,11 +207,11 @@ Additional parameters:
                     widthBoard: '250px',
                     responsive: '700',
                     colors: {
-                        'yellow': '#8C4',
-                        'blue':'#0AC',
-                        'green': '#0AC',
-                        'yellow':'#FC3',
-                        'red':'#E43'
+                      'green': '#8C4',
+                      'blue':'#0AC',
+                      'orange':'#F91'
+                      'yellow':'#FC3',
+                      'red':'#E43'
                     },
                     boards: [],
                     dragBoards: true,

--- a/src/main/resources/Macros/KanbanMacro.xml
+++ b/src/main/resources/Macros/KanbanMacro.xml
@@ -206,7 +206,13 @@ Additional parameters:
                     gutter: '15px',
                     widthBoard: '250px',
                     responsive: '700',
-                    colors: ["yellow", "green", "blue", "red", "orange"],
+                    colors: {
+                        'yellow': '#8C4',
+                        'blue':'#0AC',
+                        'green': '#0AC',
+                        'yellow':'#FC3',
+                        'red':'#E43'
+                    },
                     boards: [],
                     dragBoards: true,
                     addItemButton: false,
@@ -446,9 +452,9 @@ Additional parameters:
                         allClasses.map(function (value) {
                             headerBoard.classList.add(value);
                         });
-                        if (board.color !== '' &amp;&amp; board.color !== undefined) {
-                            headerBoard.classList.add("kanban-header-" + board.color);
-                        }
+                        // We want to keep backward compatibility with the old "color" property so we don't break existing boards.
+                        color = defaults.colors[board.color] ? defaults.colors[board.color] : board.color;
+                        headerBoard.style.background = color;
                         titleBoard = document.createElement('div');
                         titleBoard.classList.add('kanban-title-board');
                         titleBoard.innerHTML = board.title;
@@ -1981,26 +1987,6 @@ Additional parameters:
   font-weight: bold;
 }
 
-.kanban-header-yellow {
-    background: #FC3;
-}
-
-.kanban-header-orange {
-    background: #F91;
-}
-
-.kanban-header-blue {
-    background: #0AC;
-}
-
-.kanban-header-red {
-    background: #E43;
-}
-
-.kanban-header-green {
-    background: #8C4;
-}
-
 .kanban-addboard {
     float: left;
     margin: 30px;
@@ -2298,25 +2284,6 @@ require(['jquery','jkanban'], function(jQuery) {
                     kanban.inEditMode = false;
                 });
 
-            },
-            colorClick: function (el, boardId) {
-                console.log("in color click");
-                var board = jQuery(el.parentNode).attr("data-id");
-                var boardJSON = kanban.getBoardJSON(board);
-                var currentColor = boardJSON.color;
-                console.log("Current color " + currentColor);
-                var index = kanban.options.colors.findIndex(function (element) {
-                    return (element == currentColor)
-                }) + 1;
-                console.log("Next index " + index);
-                if (index &gt;= kanban.options.colors.length)
-                    index = 0;
-                var nextColor = kanban.options.colors[index];
-                console.log("Next color " + nextColor);
-                boardJSON.color = nextColor;
-                jQuery(el).removeClass("kanban-header-" + currentColor);
-                jQuery(el).addClass("kanban-header-" + nextColor);
-                kanban.onChange();
             },
             removeClick: function (el, boardId) {
                 if (confirm("Do you want to delete this board?")) {


### PR DESCRIPTION
Added the ability to select colors for all the columns of a Kanban board and removed the ability to click the header and cycle through the default colors since this feature didn't save the new color and everything was reset to the default color when pressing F5. However, if you think that this feature is a must-have and is important for the users, I can add it back.