### PR TITLE
KANBAN-10: Add a parameter to choose the categories to display

### DIFF
--- a/src/main/resources/Macros/AWMKanbanMacro.xml
+++ b/src/main/resources/Macros/AWMKanbanMacro.xml
@@ -376,11 +376,7 @@ ul.card-field-list {
   ## We set as default the original colors: green,blue,orange,yellow,red
   #set($colors = "#8C4,#0AC,#F91,#FC3,#E43")
 #end
-#if($xcontext.macro.params.displayCategories)
-  #set($displayCategories = "$xcontext.macro.params.displayCategories")
-#else
-  #set($displayCategories = "")
-#end
+#set ($displayCategories = "$!xcontext.macro.params.displayCategories")
 
 #set($width = "$xcontext.macro.params.width")
 #set($source = $xwiki.getDocument("Macros.KanbanAWMSource").getURL("get", "xpage=plain&amp;outputSyntax=plain&amp;className=${escapetool.url($className)}&amp;category=${escapetool.url($category)}&amp;displayCategories=${escapetool.url($displayCategories)}&amp;title=${escapetool.url($title)}&amp;columns=${escapetool.url($columns)}&amp;xwql=${escapetool.url($xwql)}&amp;colors=${escapetool.url($colors)}"))

--- a/src/main/resources/Macros/AWMKanbanMacro.xml
+++ b/src/main/resources/Macros/AWMKanbanMacro.xml
@@ -44,15 +44,15 @@
 Example:
 
 ##{{{
-{{awmkanban app="Help.Applications.Movies" category="databaseList1" columns="staticList1,boolean1" xwql="obj.boolean1=0" /}}
+{{awmkanban app="Help.Applications.Movies" category="databaseList1" displayCategories="Help.Applications.Contributors.Charlie Chaplin" columns="staticList1,boolean1" xwql="obj.boolean1=0" /}}
 }}}##
 
-* ##app or className## application or className for which to build the kanban board
-* ##category## field to use to break down the kanban board
-* ##categoryValues## only display these values for the categories
-* ##xwql## additional xwql to restrict the query
-* ##title## field to display the title
-* ##columns## additional columns to display
+* ##app or className## - application or className for which to build the kanban board
+* ##category## - class field used to group the kanban board into columns
+* ##displayCategories## - only display these values of the `category` field as columns
+* ##xwql## - additional xwql to restrict the query
+* ##title## - field to display the title
+* ##columns## - the class fields to display as a description in each card
 
 Examples:
 
@@ -62,7 +62,7 @@ Examples:
 
 == Kanban of Movies showing the director field, only showing a subset of directors==
 
-{{awmkanban app="Help.Applications.Movies" category="databaseList1" categoryValues="Help.Applications.Contributors.Charlie Chaplin" columns="staticList1,boolean1"/}}
+{{awmkanban app="Help.Applications.Movies" category="databaseList1" displayCategories="Help.Applications.Contributors.Charlie Chaplin" columns="staticList1,boolean1"/}}
 
 == Kanban of Movies by genre showing the director field only comedy movies ==
 
@@ -376,12 +376,14 @@ ul.card-field-list {
   ## We set as default the original colors: green,blue,orange,yellow,red
   #set($colors = "#8C4,#0AC,#F91,#FC3,#E43")
 #end
-
-#if($xcontext.macro.params.categoryValues)
-  #set($categoryValues = "&amp;categoryValues=${escapetool.url($xcontext.macro.params.categoryValues)}")
+#if($xcontext.macro.params.displayCategories)
+  #set($displayCategories = "$xcontext.macro.params.displayCategories")
+#else
+  #set($displayCategories = "")
 #end
+
 #set($width = "$xcontext.macro.params.width")
-#set($source = $xwiki.getDocument("Macros.KanbanAWMSource").getURL("get", "xpage=plain&amp;outputSyntax=plain&amp;className=${escapetool.url($className)}&amp;category=${escapetool.url($category)}$!{categoryValues}&amp;title=${escapetool.url($title)}&amp;columns=${escapetool.url($columns)}&amp;xwql=${escapetool.url($xwql)}&amp;colors=${escapetool.url($colors)}"))
+#set($source = $xwiki.getDocument("Macros.KanbanAWMSource").getURL("get", "xpage=plain&amp;outputSyntax=plain&amp;className=${escapetool.url($className)}&amp;category=${escapetool.url($category)}&amp;displayCategories=${escapetool.url($displayCategories)}&amp;title=${escapetool.url($title)}&amp;columns=${escapetool.url($columns)}&amp;xwql=${escapetool.url($xwql)}&amp;colors=${escapetool.url($colors)}"))
 #set($awmupdatepath = "/objects/${className}/0/properties/${category}/")
 {{kanban source="${source}" updateService="" addBoardButton="false" addItemButton="false" removeBoardButton="false" removeItemButton="false" awmupdatepath="${awmupdatepath}" width="${width}" /}}
 {{/velocity}}
@@ -865,7 +867,7 @@ ul.card-field-list {
       <defaultValue/>
     </property>
     <property>
-      <description>Columns to use to display additional data</description>
+      <description>The class properties to display in each card description as additional data (Comma separated values)</description>
     </property>
     <property>
       <mandatory/>
@@ -1078,13 +1080,13 @@ ul.card-field-list {
       <defaultValue/>
     </property>
     <property>
-      <description>Only display these values of the category. (Comma separated)</description>
+      <description>Only display these values of the `category` field as columns. Example: "ToDo,InProgress" (Comma separated values)</description>
     </property>
     <property>
       <mandatory>0</mandatory>
     </property>
     <property>
-      <name>categoryValues</name>
+      <name>displayCategories</name>
     </property>
     <property>
       <type/>

--- a/src/main/resources/Macros/AWMKanbanMacro.xml
+++ b/src/main/resources/Macros/AWMKanbanMacro.xml
@@ -49,7 +49,7 @@ Example:
 
 * ##app or className## application or className for which to build the kanban board
 * ##category## field to use to break down the kanban board
-* ##categoryValues## only display these values for the categories (comma separated, optional)
+* ##categoryValues## only display these values for the categories
 * ##xwql## additional xwql to restrict the query
 * ##title## field to display the title
 * ##columns## additional columns to display

--- a/src/main/resources/Macros/AWMKanbanMacro.xml
+++ b/src/main/resources/Macros/AWMKanbanMacro.xml
@@ -44,12 +44,12 @@
 Example:
 
 ##{{{
-{{awmkanban app="Help.Applications.Movies" category="databaseList1" displayCategories="Help.Applications.Contributors.Charlie Chaplin" columns="staticList1,boolean1" xwql="obj.boolean1=0" /}}
+{{awmkanban app="Help.Applications.Movies" category="databaseList1" displayedCategoryColumns="Help.Applications.Contributors.Charlie Chaplin" columns="staticList1,boolean1" xwql="obj.boolean1=0" /}}
 }}}##
 
 * ##app or className## - application or className for which to build the kanban board
 * ##category## - class field used to group the kanban board into columns
-* ##displayCategories## - only display these values of the `category` field as columns
+* ##displayedCategoryColumns## - only display these values of the `category` field as columns
 * ##xwql## - additional xwql to restrict the query
 * ##title## - field to display the title
 * ##columns## - the class fields to display as a description in each card
@@ -62,7 +62,7 @@ Examples:
 
 == Kanban of Movies showing the director field, only showing a subset of directors==
 
-{{awmkanban app="Help.Applications.Movies" category="databaseList1" displayCategories="Help.Applications.Contributors.Charlie Chaplin" columns="staticList1,boolean1"/}}
+{{awmkanban app="Help.Applications.Movies" category="databaseList1" displayedCategoryColumns="Help.Applications.Contributors.Charlie Chaplin" columns="staticList1,boolean1"/}}
 
 == Kanban of Movies by genre showing the director field only comedy movies ==
 
@@ -376,10 +376,10 @@ ul.card-field-list {
   ## We set as default the original colors: green,blue,orange,yellow,red
   #set($colors = "#8C4,#0AC,#F91,#FC3,#E43")
 #end
-#set ($displayCategories = "$!xcontext.macro.params.displayCategories")
+#set ($displayedCategoryColumns = "$!xcontext.macro.params.displayedCategoryColumns")
 
 #set($width = "$xcontext.macro.params.width")
-#set($source = $xwiki.getDocument("Macros.KanbanAWMSource").getURL("get", "xpage=plain&amp;outputSyntax=plain&amp;className=${escapetool.url($className)}&amp;category=${escapetool.url($category)}&amp;displayCategories=${escapetool.url($displayCategories)}&amp;title=${escapetool.url($title)}&amp;columns=${escapetool.url($columns)}&amp;xwql=${escapetool.url($xwql)}&amp;colors=${escapetool.url($colors)}"))
+#set($source = $xwiki.getDocument("Macros.KanbanAWMSource").getURL("get", "xpage=plain&amp;outputSyntax=plain&amp;className=${escapetool.url($className)}&amp;category=${escapetool.url($category)}&amp;displayedCategoryColumns=${escapetool.url($displayedCategoryColumns)}&amp;title=${escapetool.url($title)}&amp;columns=${escapetool.url($columns)}&amp;xwql=${escapetool.url($xwql)}&amp;colors=${escapetool.url($colors)}"))
 #set($awmupdatepath = "/objects/${className}/0/properties/${category}/")
 {{kanban source="${source}" updateService="" addBoardButton="false" addItemButton="false" removeBoardButton="false" removeItemButton="false" awmupdatepath="${awmupdatepath}" width="${width}" /}}
 {{/velocity}}
@@ -863,7 +863,7 @@ ul.card-field-list {
       <defaultValue/>
     </property>
     <property>
-      <description>The class properties to display in each card description as additional data (Comma separated values)</description>
+      <description>The class properties to display in each card description as additional data (comma separated values)</description>
     </property>
     <property>
       <mandatory/>
@@ -1076,13 +1076,13 @@ ul.card-field-list {
       <defaultValue/>
     </property>
     <property>
-      <description>Only display these values of the `category` field as columns. Example: "ToDo,InProgress" (Comma separated values)</description>
+      <description>Have only these category values as board columns, i.e. for 'ToDo,InProgress' (comma separated values) you will only have 2 kanban columns. Note that these should be values accepted by the specified category property.</description>
     </property>
     <property>
       <mandatory>0</mandatory>
     </property>
     <property>
-      <name>displayCategories</name>
+      <name>displayedCategoryColumns</name>
     </property>
     <property>
       <type/>

--- a/src/main/resources/Macros/AWMKanbanMacro.xml
+++ b/src/main/resources/Macros/AWMKanbanMacro.xml
@@ -49,6 +49,7 @@ Example:
 
 * ##app or className## application or className for which to build the kanban board
 * ##category## field to use to break down the kanban board
+* ##categoryValues## only display these values for the categories (comma separated, optional)
 * ##xwql## additional xwql to restrict the query
 * ##title## field to display the title
 * ##columns## additional columns to display
@@ -58,6 +59,10 @@ Examples:
 == Kanban of Movies by genre showing the director field ==
 
 {{awmkanban app="Help.Applications.Movies" category="databaseList1" columns="staticList1,boolean1"/}}
+
+== Kanban of Movies showing the director field, only showing a subset of directors==
+
+{{awmkanban app="Help.Applications.Movies" category="databaseList1" categoryValues="Help.Applications.Contributors.Charlie Chaplin" columns="staticList1,boolean1"/}}
 
 == Kanban of Movies by genre showing the director field only comedy movies ==
 
@@ -372,8 +377,11 @@ ul.card-field-list {
   #set($colors = "#8C4,#0AC,#F91,#FC3,#E43")
 #end
 
+#if($xcontext.macro.params.categoryValues)
+  #set($categoryValues = "&amp;categoryValues=${escapetool.url($xcontext.macro.params.categoryValues)}")
+#end
 #set($width = "$xcontext.macro.params.width")
-#set($source = $xwiki.getDocument("Macros.KanbanAWMSource").getURL("get", "xpage=plain&amp;outputSyntax=plain&amp;className=${escapetool.url($className)}&amp;category=${escapetool.url($category)}&amp;title=${escapetool.url($title)}&amp;columns=${escapetool.url($columns)}&amp;xwql=${escapetool.url($xwql)}&amp;colors=${escapetool.url($colors)}"))
+#set($source = $xwiki.getDocument("Macros.KanbanAWMSource").getURL("get", "xpage=plain&amp;outputSyntax=plain&amp;className=${escapetool.url($className)}&amp;category=${escapetool.url($category)}$!{categoryValues}&amp;title=${escapetool.url($title)}&amp;columns=${escapetool.url($columns)}&amp;xwql=${escapetool.url($xwql)}&amp;colors=${escapetool.url($colors)}"))
 #set($awmupdatepath = "/objects/${className}/0/properties/${category}/")
 {{kanban source="${source}" updateService="" addBoardButton="false" addItemButton="false" removeBoardButton="false" removeItemButton="false" awmupdatepath="${awmupdatepath}" width="${width}" /}}
 {{/velocity}}
@@ -1008,6 +1016,75 @@ ul.card-field-list {
     </property>
     <property>
       <name>colors</name>
+    </property>
+    <property>
+      <type/>
+    </property>
+  </object>
+  <object>
+    <name>Macros.AWMKanbanMacro</name>
+    <number>12</number>
+    <className>XWiki.WikiMacroParameterClass</className>
+    <guid>142486fa-b3c6-4286-81a3-f07d98bcc3b8</guid>
+    <class>
+      <name>XWiki.WikiMacroParameterClass</name>
+      <customClass/>
+      <customMapping/>
+      <defaultViewSheet/>
+      <defaultEditSheet/>
+      <defaultWeb/>
+      <nameField/>
+      <validationScript/>
+      <defaultValue>
+        <disabled>0</disabled>
+        <name>defaultValue</name>
+        <number>4</number>
+        <prettyName>Parameter default value</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </defaultValue>
+      <description>
+        <disabled>0</disabled>
+        <name>description</name>
+        <number>2</number>
+        <prettyName>Parameter description</prettyName>
+        <rows>5</rows>
+        <size>40</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
+      </description>
+      <mandatory>
+        <disabled>0</disabled>
+        <displayFormType>select</displayFormType>
+        <displayType>yesno</displayType>
+        <name>mandatory</name>
+        <number>3</number>
+        <prettyName>Parameter mandatory</prettyName>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
+      </mandatory>
+      <name>
+        <disabled>0</disabled>
+        <name>name</name>
+        <number>1</number>
+        <prettyName>Parameter name</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </name>
+    </class>
+    <property>
+      <defaultValue/>
+    </property>
+    <property>
+      <description>Only display these values of the category. (Comma separated)</description>
+    </property>
+    <property>
+      <mandatory>0</mandatory>
+    </property>
+    <property>
+      <name>categoryValues</name>
     </property>
     <property>
       <type/>

--- a/src/main/resources/Macros/KanbanAWMSource.xml
+++ b/src/main/resources/Macros/KanbanAWMSource.xml
@@ -107,9 +107,9 @@
     #set($query = "${query} order by obj.${order}")
    #end
   #end
-  #if($request.categoryValues)
+  #if("$!request.displayCategories" != '')
     ## Only display a subset of all categories
-    #set($categoryValues = $request.categoryValues.split(","))
+    #set($categoryValues = $request.displayCategories.split(","))
   #end
   #if($request.debug)
   /* {{{ $query }}} */

--- a/src/main/resources/Macros/KanbanAWMSource.xml
+++ b/src/main/resources/Macros/KanbanAWMSource.xml
@@ -107,9 +107,9 @@
     #set($query = "${query} order by obj.${order}")
    #end
   #end
-  #if ("$!request.displayCategories" != '')
-    ## Only display a subset of all categories
-    #set ($categoryValues = $request.displayCategories.split(','))
+  #if ("$!request.displayedCategoryColumns" != '')
+    ## Only display a subset of all categories.
+    #set ($selectedCategoryValues = $request.displayedCategoryColumns.split(','))
   #end
   #if($request.debug)
   /* {{{ $query }}} */
@@ -119,17 +119,38 @@
   #if($request.debug)
   /* {{{ $results }}} */
   #end
-  #if ($categoryValues)
-    #set ($categories = $categoryValues)
-  #else
-    #set ($categoryField = $xwiki.getDocument($className).getxWikiClass().get($category))
-    #set ($categories = $categoryField.getListValues())
+  #set ($categoryField = $xwiki.getDocument($className).getxWikiClass().get($category))
+  #set ($categories = $categoryField.getListValues())
+
+  #if ($selectedCategoryValues)
+    ## Validate the requested category values.
+    #if ($categories)
+      ## Remove values not in the set of possible values (if there is such a set).
+      #set ($validatedCategoryValues = [])
+      #foreach ($selectedCategoryValue in $selectedCategoryValues)
+        #if ($categories.contains($selectedCategoryValue))
+          #set ($discard = $validatedCategoryValues.add($selectedCategoryValue))
+        #end
+      #end
+      #set ($selectedCategoryValues = $validatedCategoryValues)
+    #end
+
+    ## Remove duplicate values (only leave the first one of each unique value).
+    #set ($validatedCategoryValues = [])
+    #foreach ($selectedCategoryValue in $selectedCategoryValues)
+      #if (!$validatedCategoryValues.contains($selectedCategoryValue))
+        #set ($discard = $validatedCategoryValues.add($selectedCategoryValue))
+      #end
+    #end
+
+    #set ($categories = $validatedCategoryValues)
   #end
+
   #set($categoriesDocs = $util.hashMap)
   #foreach($currentpage in $results)
     #set($currentdoc = $xwiki.getDocument($currentpage))
     #set($value = $currentdoc.getValue($category))
-    #if(!$categories.contains($value) &amp;&amp; !$categoryValues)
+    #if(!$categories.contains($value) &amp;&amp; !$selectedCategoryValues)
      #set($discard = $categories.add($value))
     #end
     #set($docList = $categoriesDocs.get($value))

--- a/src/main/resources/Macros/KanbanAWMSource.xml
+++ b/src/main/resources/Macros/KanbanAWMSource.xml
@@ -107,6 +107,10 @@
     #set($query = "${query} order by obj.${order}")
    #end
   #end
+  #if($request.categoryValues)
+    ## Only display a subset of all categories
+    #set($categoryValues = $request.categoryValues.split(","))
+  #end
   #if($request.debug)
   /* {{{ $query }}} */
   #end
@@ -115,13 +119,17 @@
   #if($request.debug)
   /* {{{ $results }}} */
   #end
-  #set($categoryField = $xwiki.getDocument($className).getxWikiClass().get($category))
-  #set($categories = $categoryField.getListValues())
+  #if($categoryValues)
+    #set($categories = $categoryValues)
+  #else
+    #set($categoryField = $xwiki.getDocument($className).getxWikiClass().get($category))
+    #set($categories = $categoryField.getListValues())
+  #end
   #set($categoriesDocs = $util.hashMap)
   #foreach($currentpage in $results)
     #set($currentdoc = $xwiki.getDocument($currentpage))
     #set($value = $currentdoc.getValue($category))
-    #if(!$categories.contains($value))
+    #if(!$categories.contains($value) &amp;&amp; !$categoryValues)
      #set($discard = $categories.add($value))
     #end
     #set($docList = $categoriesDocs.get($value))

--- a/src/main/resources/Macros/KanbanAWMSource.xml
+++ b/src/main/resources/Macros/KanbanAWMSource.xml
@@ -109,7 +109,7 @@
   #end
   #if ("$!request.displayedCategoryColumns" != '')
     ## Only display a subset of all categories.
-    #set ($selectedCategoryValues = $request.displayedCategoryColumns.split(','))
+    #set ($selectedCategories = $request.displayedCategoryColumns.split(','))
   #end
   #if($request.debug)
   /* {{{ $query }}} */
@@ -121,26 +121,26 @@
   #end
   #set ($categoryField = $xwiki.getDocument($className).getxWikiClass().get($category))
   #set ($categories = $categoryField.getListValues())
-  #if ($selectedCategoryValues)
+  #if ($selectedCategories)
     ## Validate the requested category values:
     ## Remove values not in the set of possible values (if there is such a set).
     ## Remove duplicate values (only leave the first one of each unique value).
-    #set ($validatedCategoryValues = [])
-    #foreach ($selectedCategoryValue in $selectedCategoryValues)
+    #set ($validatedCategories = [])
+    #foreach ($selectedCategory in $selectedCategories)
       #if (
-        $categories.contains($selectedCategoryValue) &amp;&amp;
-        !$validatedCategoryValues.contains($selectedCategoryValue)
+        $categories.contains($selectedCategory) &amp;&amp;
+        !$validatedCategories.contains($selectedCategory)
       )
-        #set ($discard = $validatedCategoryValues.add($selectedCategoryValue))
+        #set ($discard = $validatedCategories.add($selectedCategory))
       #end
     #end
-    #set ($categories = $validatedCategoryValues)
+    #set ($categories = $validatedCategories)
   #end
   #set($categoriesDocs = $util.hashMap)
   #foreach($currentpage in $results)
     #set($currentdoc = $xwiki.getDocument($currentpage))
     #set($value = $currentdoc.getValue($category))
-    #if(!$categories.contains($value) &amp;&amp; !$selectedCategoryValues)
+    #if(!$categories.contains($value) &amp;&amp; (!$selectedCategories || $selectedCategories.contains($value)))
      #set($discard = $categories.add($value))
     #end
     #set($docList = $categoriesDocs.get($value))

--- a/src/main/resources/Macros/KanbanAWMSource.xml
+++ b/src/main/resources/Macros/KanbanAWMSource.xml
@@ -109,7 +109,7 @@
   #end
   #if("$!request.displayCategories" != '')
     ## Only display a subset of all categories
-    #set($categoryValues = $request.displayCategories.split(","))
+    #set($categoryValues = $request.displayCategories.split(','))
   #end
   #if($request.debug)
   /* {{{ $query }}} */

--- a/src/main/resources/Macros/KanbanAWMSource.xml
+++ b/src/main/resources/Macros/KanbanAWMSource.xml
@@ -121,31 +121,21 @@
   #end
   #set ($categoryField = $xwiki.getDocument($className).getxWikiClass().get($category))
   #set ($categories = $categoryField.getListValues())
-
   #if ($selectedCategoryValues)
-    ## Validate the requested category values.
-    #if ($categories)
-      ## Remove values not in the set of possible values (if there is such a set).
-      #set ($validatedCategoryValues = [])
-      #foreach ($selectedCategoryValue in $selectedCategoryValues)
-        #if ($categories.contains($selectedCategoryValue))
-          #set ($discard = $validatedCategoryValues.add($selectedCategoryValue))
-        #end
-      #end
-      #set ($selectedCategoryValues = $validatedCategoryValues)
-    #end
-
+    ## Validate the requested category values:
+    ## Remove values not in the set of possible values (if there is such a set).
     ## Remove duplicate values (only leave the first one of each unique value).
     #set ($validatedCategoryValues = [])
     #foreach ($selectedCategoryValue in $selectedCategoryValues)
-      #if (!$validatedCategoryValues.contains($selectedCategoryValue))
+      #if (
+        $categories.contains($selectedCategoryValue) &amp;&amp;
+        !$validatedCategoryValues.contains($selectedCategoryValue)
+      )
         #set ($discard = $validatedCategoryValues.add($selectedCategoryValue))
       #end
     #end
-
     #set ($categories = $validatedCategoryValues)
   #end
-
   #set($categoriesDocs = $util.hashMap)
   #foreach($currentpage in $results)
     #set($currentdoc = $xwiki.getDocument($currentpage))

--- a/src/main/resources/Macros/KanbanAWMSource.xml
+++ b/src/main/resources/Macros/KanbanAWMSource.xml
@@ -107,9 +107,9 @@
     #set($query = "${query} order by obj.${order}")
    #end
   #end
-  #if("$!request.displayCategories" != '')
+  #if ("$!request.displayCategories" != '')
     ## Only display a subset of all categories
-    #set($categoryValues = $request.displayCategories.split(','))
+    #set ($categoryValues = $request.displayCategories.split(','))
   #end
   #if($request.debug)
   /* {{{ $query }}} */
@@ -119,11 +119,11 @@
   #if($request.debug)
   /* {{{ $results }}} */
   #end
-  #if($categoryValues)
-    #set($categories = $categoryValues)
+  #if ($categoryValues)
+    #set ($categories = $categoryValues)
   #else
-    #set($categoryField = $xwiki.getDocument($className).getxWikiClass().get($category))
-    #set($categories = $categoryField.getListValues())
+    #set ($categoryField = $xwiki.getDocument($className).getxWikiClass().get($category))
+    #set ($categories = $categoryField.getListValues())
   #end
   #set($categoriesDocs = $util.hashMap)
   #foreach($currentpage in $results)


### PR DESCRIPTION
Fixes [\[KANBAN-10\] Add a parameter to choose the categories to display](https://jira.xwiki.org/browse/KANBAN-10)
* Added parameter ```displayedCategoryColumns``` to choose the categories to display
* Added documentation for the new parameter
* Duplicate category columns will be removed, leaving only the first occurrence
* Category columns which are not in the list of possible values of the ```category``` field are automatically removed (to prevent invalid values from propagating)

Before this PR only the following is possible:
![image](https://github.com/user-attachments/assets/0fe296cc-f2e7-4a68-bb41-0aa84cd7d8c4)
In this case, ```ToDo```, ```InProgress``` and ```Done``` are all the possible values of the category field.

Examples of what this PR adds, using classes from the Task Manager Application:
* Choose the order of categories
```
{{awmkanban className="TaskManager.TaskManagerClass" category="status" displayCategories="Done,ToDo,InProgress" title="name" columns="assignee,progress,duedate" width="32%" colors="orange,green,blue"/}}
```
![image](https://github.com/user-attachments/assets/8b52826b-74d4-4b9a-9c0e-254d4eaa2e13)
* Choose the categories to display
```
{{awmkanban className="TaskManager.TaskManagerClass" category="status" displayCategories="ToDo,InProgress" title="name" columns="assignee,progress,duedate" width="32%" colors="green,blue"/}}
```
![image](https://github.com/user-attachments/assets/fb912872-7adc-4a5e-81d3-202c37b40ff7)