### PR TITLE
KANBAN-11: Null category appears when user doesn't have view permission on an object

### DIFF
--- a/src/main/resources/Macros/KanbanAWMSource.xml
+++ b/src/main/resources/Macros/KanbanAWMSource.xml
@@ -140,7 +140,7 @@
   #foreach($currentpage in $results)
     #set($currentdoc = $xwiki.getDocument($currentpage))
     #set($value = $currentdoc.getValue($category))
-    #if(!$categories.contains($value) &amp;&amp; $value &amp;&amp; (!$selectedCategories || $selectedCategories.contains($value)))
+    #if($value &amp;&amp; !$categories.contains($value) &amp;&amp; (!$selectedCategories || $selectedCategories.contains($value)))
      #set($discard = $categories.add($value))
     #end
     #set($docList = $categoriesDocs.get($value))

--- a/src/main/resources/Macros/KanbanAWMSource.xml
+++ b/src/main/resources/Macros/KanbanAWMSource.xml
@@ -140,7 +140,7 @@
   #foreach($currentpage in $results)
     #set($currentdoc = $xwiki.getDocument($currentpage))
     #set($value = $currentdoc.getValue($category))
-    #if(!$categories.contains($value) &amp;&amp; (!$selectedCategories || $selectedCategories.contains($value)))
+    #if(!$categories.contains($value) &amp;&amp; $value &amp;&amp; (!$selectedCategories || $selectedCategories.contains($value)))
      #set($discard = $categories.add($value))
     #end
     #set($docList = $categoriesDocs.get($value))


### PR DESCRIPTION
* Added null check to prevent ghost category

Before:
![image](https://github.com/user-attachments/assets/5d1ba683-7655-4e67-bdae-8f21951be383)
After:
![image](https://github.com/user-attachments/assets/ff889787-f66f-4679-baf8-819506a7e69f)
