### PR TITLE
KANBAN-18: Card titles with special characters causes HTML macro output in Kanban

### DIFF
--- a/src/main/resources/Macros/KanbanAWMSource.xml
+++ b/src/main/resources/Macros/KanbanAWMSource.xml
@@ -38,71 +38,75 @@
   <hidden>true</hidden>
   <content>{{velocity wiki='false'}}
 #if ($xcontext.action == 'get')
-  #set($ok = $response.setContentType("application/json"))
-  #set($colors = $request.colors.split(','))
-  #macro(displayCategories $categories $docLists)
-  #set($map = [])
-  #foreach($categoryValue in $categories)
-       #set($fakedoc = $xwiki.getDocument("XWiki.FakeDocument"))
-       #set($fakeobj = $fakedoc.getObject($className, true))
-       #set($discard = $fakedoc.use($fakeobj))
-       #set($discard = $fakedoc.set($category, $categoryValue))
-       #set($scategoryValue = $fakedoc.display($category, "view", $fakeobj).replaceFirst($regextool.quote('{{html clean="false" wiki="false"}}'), '').replaceAll("$regextool.quote('{{/html}}')$", ''))
-       #set($items = [])
-       #foreach($docname in $docLists.get($categoryValue))
-                #set($currentDoc = $xwiki.getDocument($docname))
-                #set($surl = $currentDoc.getURL("view"))
-                #if($request.title &amp;&amp; $request.title != "")
-                 #if($request.title=="title")
-                  #set($title = $currentDoc.title)
-                 #else
-                  #set($stitle = $currentDoc.display($request.title))
-                 #end
-                #else
-                 #set($stitle = $currentDoc.getDisplayTitle())
-                #end
-                #set($scontent = "")
-                #if($request.columns &amp;&amp; $request.columns!="")
-                 #set($scontent = "&lt;ul class='card-field-list'&gt;")
-                 #foreach($col in $request.columns.split(","))
-                  #set($value = $currentDoc.display($col).replaceFirst($regextool.quote('{{html clean="false" wiki="false"}}'), '').replaceAll("$regextool.quote('{{/html}}')$", ''))
-                  #set($pname = $currentDoc.displayPrettyName($col))
-                  #set($scontent = "${scontent}&lt;li class='card-field'&gt;&lt;span class='card-field-title''&gt;${escapetool.xml($pname)}&lt;/span&gt;&lt;span class='card-field-value'&gt;$value&lt;/span&gt;&lt;/li&gt;")
-                 #end
-                 #set($scontent = "${scontent}&lt;/ul&gt;")
-                #end
-                #set ($docid = "$currentDoc.getDocumentReference()")
-                #set($itemmap = { "id" : $docid, "title" : $stitle, "url": $surl, "content" : $scontent })
-                #set($ok = $items.add($itemmap))
+  #set ($ok = $response.setContentType("application/json"))
+  #set ($colors = $request.colors.split(','))
+  #macro (displayCategories $categories $docLists)
+  #set ($map = [])
+  #foreach ($categoryValue in $categories)
+    #set ($fakedoc = $xwiki.getDocument("XWiki.FakeDocument"))
+    #set ($fakeobj = $fakedoc.getObject($className, true))
+    #set ($discard = $fakedoc.use($fakeobj))
+    #set ($discard = $fakedoc.set($category, $categoryValue))
+    #set ($scategoryValue = $fakedoc.display($category, "view", $fakeobj).replaceFirst(
+$regextool.quote('{{html clean="false" wiki="false"}}'), '').replaceAll("$regextool.quote('{{/html}}')$", ''))
+    #set ($items = [])
+    #foreach ($docname in $docLists.get($categoryValue))
+      #set ($currentDoc = $xwiki.getDocument($docname))
+      #set ($surl = $currentDoc.getURL("view"))
+      #if ($request.title &amp;&amp; $request.title != "")
+        #if ($request.title=="title")
+          #set ($title = $currentDoc.title)
+        #else
+          #set ($stitle = $currentDoc.display($request.title).replaceFirst(
+$regextool.quote('{{html clean="false" wiki="false"}}'), '').replaceAll("$regextool.quote('{{/html}}')$", ''))
         #end
-       #set($color = $listtool.get($colors, $foreach.index).strip())
-       #if(!$color)
-        #set($color = "blue")
-       #end
-       #set($ok = $map.add({ "id" : $categoryValue, "title" : $scategoryValue, "color" : "${color}", "item" : $items }))
-     #end
+      #else
+        #set ($stitle = $currentDoc.getDisplayTitle())
+      #end
+      #set ($scontent = "")
+      #if ($request.columns &amp;&amp; $request.columns != "")
+        #set ($scontent = "&lt;ul class='card-field-list'&gt;")
+        #foreach ($col in $request.columns.split(","))
+          #set ($value = $currentDoc.display($col).replaceFirst(
+$regextool.quote('{{html clean="false" wiki="false"}}'), '').replaceAll("$regextool.quote('{{/html}}')$", ''))
+          #set ($pname = $currentDoc.displayPrettyName($col))
+          #set ($scontent = "${scontent}&lt;li class='card-field'&gt;&lt;span class='card-field-title''&gt;
+${escapetool.xml($pname)}&lt;/span&gt;&lt;span class='card-field-value'&gt;$value&lt;/span&gt;&lt;/li&gt;")
+        #end
+        #set ($scontent = "${scontent}&lt;/ul&gt;")
+      #end
+      #set ($docid = "$currentDoc.getDocumentReference()")
+      #set ($itemmap = { "id" : $docid, "title" : $stitle, "url": $surl, "content" : $scontent })
+      #set ($ok = $items.add($itemmap))
+    #end
+    #set ($color = $listtool.get($colors, $foreach.index).strip())
+    #if (!$color)
+      #set ($color = "blue")
+    #end
+    #set ($ok = $map.add({ "id" : $categoryValue, "title" : $scategoryValue, "color" : "${color}", "item" : $items }))
+  #end
   $jsontool.serialize(${map})
   #end
-  #if($request.className||$request.app)
-  #set($app = $request.app)
-  #set($className = $request.className)
-  #if(!$className || $className=="")
-   #set($appDoc = $xwiki.getDocument("${app}.WebHome"))
-   #set($className = $appDoc.getValue("class"))
+  #if ($request.className || $request.app)
+  #set ($app = $request.app)
+  #set ($className = $request.className)
+  #if (!$className || $className == "")
+    #set ($appDoc = $xwiki.getDocument("${app}.WebHome"))
+    #set ($className = $appDoc.getValue("class"))
   #end
-  #set($category = $request.category)
-  #set($query = "from doc.object(${className}) as obj where doc.fullName not like '%Template'")
+  #set ($category = $request.category)
+  #set ($query = "from doc.object(${className}) as obj where doc.fullName not like '%Template'")
   #if ("$!request.displayedCategoryColumns" != '')
     ## Only display a subset of all categories.
     #set ($query = "${query} and obj.${category}=:categoryValue")
     #set ($selectedCategories = $request.displayedCategoryColumns.split(','))
   #end
-  #set($xwql = $request.xwql)
-  #if($xwql &amp;&amp; $xwql!="")
-   #set($query = "${query} and ${xwql}")
+  #set ($xwql = $request.xwql)
+  #if ($xwql &amp;&amp; $xwql != "")
+    #set ($query = "${query} and ${xwql}")
   #end
-  #set($order = $request.order)
-  #if($order &amp;&amp; $order!="")
+  #set ($order = $request.order)
+  #if ($order &amp;&amp; $order != '')
     #set ($orderFragments = '')
     #foreach ($orderFragment in $order.split(','))
       #set ($orderFragment = $orderFragment.trim())
@@ -134,7 +138,7 @@
     #end
     #set ($categories = $validatedCategories)
   #end
-  #set($categoriesDocs = $util.hashMap)
+  #set ($categoriesDocs = $util.hashMap)
   #set ($limit = $request.limit)
   #if ("$!limit" == '')
     #set ($limit = 50)
@@ -154,12 +158,12 @@
       #set ($currentdoc = $xwiki.getDocument($currentpage))
       #set ($value = $currentdoc.getValue($category))
       #if ($value &amp;&amp; !$categories.contains($value))
-       #set ($discard = $categories.add($value))
+        #set ($discard = $categories.add($value))
       #end
       #set ($docList = $categoriesDocs.get($value))
       #if (!$docList)
-       #set ($docList = [])
-       #set ($discard = $categoriesDocs.put($value, $docList))
+        #set ($docList = [])
+        #set ($discard = $categoriesDocs.put($value, $docList))
       #end
       #set ($discard = $docList.add($currentdoc.prefixedFullName))
     #end
@@ -167,5 +171,6 @@
   #displayCategories($categories $categoriesDocs)
   #end
 #end
-{{/velocity}}</content>
+{{/velocity}}
+</content>
 </xwikidoc>


### PR DESCRIPTION
### Jira URL

[KANBAN-18](https://jira.xwiki.org/browse/KANBAN-18)

### Changes

* I've added same call of `.replaceFirst($regextool.quote('{{html clean="false" wiki="false"}}'), '').replaceAll("$regextool.quote('{{/html}}')$", '')` as it was used before in code logic
* Splitted long lines into 2 - not longer than 120 characters
* Formated content added empty space after call of specific Velocity variables, added extra indentation, spaces between statements in conditions

### Screenshots

- Before PR

<img width="1138" height="696" alt="Screenshot 2026-02-17 at 12-06-31 Sandbox Test Page 2 - XWiki" src="https://github.com/user-attachments/assets/19d815b5-b1d1-4ea2-b752-520b555d3a6b" />

- After PR

<img width="1134" height="607" alt="Screenshot 2026-02-17 at 12-07-11 Sandbox Test Page 2 - XWiki" src="https://github.com/user-attachments/assets/9cb89a0e-07bb-426c-ae24-9c09d941f493" />

### Executed Tests

Only clean build in Maven after changes
 