### PR TITLE
KANBAN-17: Replace deprecated methods with relevant ones

### DIFF
--- a/src/main/resources/Macros/KanbanAWMSource.xml
+++ b/src/main/resources/Macros/KanbanAWMSource.xml
@@ -79,7 +79,7 @@ ${escapetool.xml($pname)}&lt;/span&gt;&lt;span class='card-field-value'&gt;$valu
       #set ($itemmap = { "id" : $docid, "title" : $stitle, "url": $surl, "content" : $scontent })
       #set ($ok = $items.add($itemmap))
     #end
-    #set ($color = $listtool.get($colors, $foreach.index).strip())
+    #set ($color = $colors.get($foreach.index).strip())
     #if (!$color)
       #set ($color = "blue")
     #end
@@ -138,7 +138,7 @@ ${escapetool.xml($pname)}&lt;/span&gt;&lt;span class='card-field-value'&gt;$valu
     #end
     #set ($categories = $validatedCategories)
   #end
-  #set ($categoriesDocs = $util.hashMap)
+  #set ($categoriesDocs = {})
   #set ($limit = $request.limit)
   #if ("$!limit" == '')
     #set ($limit = 50)

--- a/src/main/resources/Macros/KanbanMacro.xml
+++ b/src/main/resources/Macros/KanbanMacro.xml
@@ -185,7 +185,7 @@ Additional parameters:
          * jKanban
          * Vanilla Javascript plugin for manage kanban boards
          *
-         * @site: http://www.riccardotartaglia.it/jkanban/
+         * @url: http://www.riccardotartaglia.it/jkanban/
          * @author: Riccardo Tartaglia
          */
 
@@ -2299,7 +2299,7 @@ Additional parameters:
 &lt;script type="text/javascript"&gt;
 require.config({
   paths: {
-    jkanban: '$xwiki.getURL("Macros.KanbanMacro", "jsx", "language=${xcontext.language}")'
+    jkanban: '$xwiki.getURL("Macros.KanbanMacro", "jsx", "language=${xcontext.locale}")'
   }
 });
 require(['jquery','jkanban'], function(jQuery) {


### PR DESCRIPTION
### Jira URL

[KANBAN-17](https://jira.xwiki.org/browse/KANBAN-17)

### Changes

* Replaced deprecated Velocity methods and variables with relevant ones
* Replaced `Site` with `@url` as relevant JSDoc according to [ParseConfig](https://github.com/google/closure-compiler/blob/0f427ee219ec53be22a90f00ca6f713567702f14/src/com/google/javascript/jscomp/parsing/ParserConfig.properties)

### Screenshots

None

### Executed Tests

- Local test creating a Kanban board with an example or tasks and monitor server logs for any warnings about deprecated methods.
- Clean build in Maven after changes
 